### PR TITLE
wait status arg is not required

### DIFF
--- a/lib/interface/cli/commands/workflow/wait.cmd.js
+++ b/lib/interface/cli/commands/workflow/wait.cmd.js
@@ -21,8 +21,7 @@ const annotate = new Command({
                 describe: 'Build status',
                 alias: 's',
                 choices: ['pending', 'elected', 'running', 'error', 'success', 'terminating', 'terminated'],
-                default: 'success',
-                required: true,
+                default: 'success'
             })
             .option('debug', {
                 alias: 'd',


### PR DESCRIPTION
wait status arg is not required because it has a default value