### PR TITLE
sharing policy support during git context creation

### DIFF
--- a/lib/interface/cli/commands/context/create/git/base.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/base.cmd.js
@@ -18,7 +18,7 @@ const command = new Command({
     },
     builder: (yargs) => {
         yargs.option('sharing-policy', {
-            describe: 'Set the sharing policy for the context',
+            describe: 'Set the sharing policy for git contexts',
             choices: ['AccountAdmins', 'AllUsersInAccount'],
             default: 'AccountAdmins',
         });

--- a/lib/interface/cli/commands/context/create/git/base.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/base.cmd.js
@@ -17,6 +17,11 @@ const command = new Command({
         title: 'Create Git Context',
     },
     builder: (yargs) => {
+        yargs.option('sharing-policy', {
+            describe: 'Set the sharing policy for the context',
+            choices: ['AccountAdmins', 'AllUsersInAccount'],
+            default: 'AccountAdmins',
+        });
         return yargs;
     },
     handler: async (argv) => {

--- a/lib/interface/cli/commands/context/create/git/types/bitbucket.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/bitbucket.cmd.js
@@ -44,6 +44,7 @@ const command = new Command({
             spec: {
                 type: 'git.bitbucket',
                 data: {
+                    allowUsingByNonAdmins: argv.share,
                     host: 'bitbucket.org',
                     useSSL: true,
                     auth: {

--- a/lib/interface/cli/commands/context/create/git/types/bitbucket.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/bitbucket.cmd.js
@@ -44,7 +44,7 @@ const command = new Command({
             spec: {
                 type: 'git.bitbucket',
                 data: {
-                    allowUsingByNonAdmins: argv.share,
+                    sharingPolicy: argv.sharingPolicy,
                     host: 'bitbucket.org',
                     useSSL: true,
                     auth: {

--- a/lib/interface/cli/commands/context/create/git/types/github.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/github.cmd.js
@@ -53,6 +53,7 @@ const command = new Command({
             spec: {
                 type: 'git.github',
                 data: {
+                    sharingPolicy: argv.sharingPolicy,
                     host: argv.host || 'github.com',
                     useSSL: Boolean(argv.useSSL) || true,
                     auth: {

--- a/lib/interface/cli/commands/context/create/git/types/gitlab.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/gitlab.cmd.js
@@ -53,7 +53,7 @@ const command = new Command({
             spec: {
                 type: 'git.gitlab',
                 data: {
-                    allowUsingByNonAdmins: argv.share,
+                    sharingPolicy: argv.sharingPolicy,
                     host: argv.host || 'gitlab.com',
                     useSSL: Boolean(argv.useSSL) || true,
                     auth: {

--- a/lib/interface/cli/commands/context/create/git/types/gitlab.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/gitlab.cmd.js
@@ -53,6 +53,7 @@ const command = new Command({
             spec: {
                 type: 'git.gitlab',
                 data: {
+                    allowUsingByNonAdmins: argv.share,
                     host: argv.host || 'gitlab.com',
                     useSSL: Boolean(argv.useSSL) || true,
                     auth: {

--- a/lib/interface/cli/commands/context/create/git/types/stash.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/stash.cmd.js
@@ -56,7 +56,7 @@ const command = new Command({
             spec: {
                 type: 'git.stash',
                 data: {
-                    allowUsingByNonAdmins: argv.share,
+                    sharingPolicy: argv.sharingPolicy,
                     host: argv.host || 'stash.com',
                     useSSL: Boolean(argv.useSSL) || true,
                     auth: {

--- a/lib/interface/cli/commands/context/create/git/types/stash.cmd.js
+++ b/lib/interface/cli/commands/context/create/git/types/stash.cmd.js
@@ -56,6 +56,7 @@ const command = new Command({
             spec: {
                 type: 'git.stash',
                 data: {
+                    allowUsingByNonAdmins: argv.share,
                     host: argv.host || 'stash.com',
                     useSSL: Boolean(argv.useSSL) || true,
                     auth: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.8.60",
+  "version": "0.8.61",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
Add flag to context creation `sharing-policy` which can be either `AccountAdmins` or `AllUsersInAccount`
* AccountAdmins - allow all admins in the account to use this context - default
* AllUsersInAccount - allow all users to use this context