### PR TITLE
Add global --no-auth flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Commands:
   codefresh test-release [name]    Test a helm release.
 
 Options:
+  --no-auth   Make anonymous API requests, do not pass API token  [boolean]
   --cfconfig  Custom path for authentication contexts config file  [default: "/Users/itaigendler/.cfconfig"]
   --help      Show help  [boolean]
 ```

--- a/lib/interface/cli/codefresh
+++ b/lib/interface/cli/codefresh
@@ -25,7 +25,7 @@ recursive(path.resolve(__dirname, 'commands'), (err, files) => {
     yargs
         .env('')
         .options('no-auth', {
-            description: 'Make anonymous API requests, do not use auth context',
+            description: 'Make anonymous API requests, do not pass API token',
             type: 'boolean',
             global: true,
         })

--- a/lib/interface/cli/codefresh
+++ b/lib/interface/cli/codefresh
@@ -24,6 +24,11 @@ recursive(path.resolve(__dirname, 'commands'), (err, files) => {
     const rootCommands = [];
     yargs
         .env('')
+        .options('no-auth', {
+            description: 'Make anonymous API requests, do not use auth context',
+            type: 'boolean',
+            global: true,
+        })
         .options('cfconfig', {
             default: DEFAULTS.CFCONFIG,
             global: false,

--- a/lib/interface/cli/helpers/general.js
+++ b/lib/interface/cli/helpers/general.js
@@ -22,6 +22,8 @@ const wrapHandler = (handler, requiresAuthentication) => {
             if (requiresAuthentication && !authManager.getCurrentContext()) {
                 printError(new CFError('Authentication error: Please create an authentication context (see codefresh auth create-context --help)'));
                 process.exit(1);
+            } else if (argv.noAuth) {
+                authManager.setNoAuth();
             }
 
             if (!argv.watch) {

--- a/lib/logic/auth/contexts/APIKeyContext.js
+++ b/lib/logic/auth/contexts/APIKeyContext.js
@@ -17,11 +17,12 @@ class APIKeyContext extends Context {
     }
 
     prepareHttpOptions() {
+        const headers = this.noAuth ? {} : {
+            Authorization: this.token,
+        };
         return {
             baseUrl: this.url,
-            headers: {
-                Authorization: this.token,
-            },
+            headers,
         };
     }
 

--- a/lib/logic/auth/manager.js
+++ b/lib/logic/auth/manager.js
@@ -153,6 +153,13 @@ class Manager {
 
         fs.writeFileSync(this._getConfigFilePath(), yaml.safeDump(newContextFile), 'utf8');
     }
+
+    /**
+     * Sets the noAuth attribute on current context
+     */
+    setNoAuth() {
+        this.getCurrentContext().noAuth = true;
+    }
 }
 
 module.exports = new Manager();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
Adding `--no-auth` flag which will prevent passing the `Authorization` header when making API requests.

Still requires an auth context to be set, in order to determine the baseUrl.

Example "logs" command with flag omitted:
```
$ DEBUG=codefresh* lib/interface/cli/codefresh logs 5b48da35844373237e4d5953
  codefresh:http Sending http request:
  codefresh:http { url: '/api/builds/5b48da35844373237e4d5953',
  codefresh:http   method: 'GET',
  codefresh:http   baseUrl: 'http://local.codefresh.io',
  codefresh:http   headers:
  codefresh:http    { Authorization: '************************.********************************',
  codefresh:http      'User-Agent': 'codefresh-cli-v0.8.64',
  codefresh:http      'Codefresh-Agent': 'cli' },
  codefresh:http   json: true,
  codefresh:http   timeout: 30000 } +0ms
```

Example "logs" command with flag present:
```
$ DEBUG=codefresh* lib/interface/cli/codefresh --no-auth logs 5b48da35844373237e4d5953
  codefresh:http Sending http request:
  codefresh:http { url: '/api/builds/5b48da35844373237e4d5953',
  codefresh:http   method: 'GET',
  codefresh:http   baseUrl: 'http://local.codefresh.io',
  codefresh:http   headers:
  codefresh:http    { 'User-Agent': 'codefresh-cli-v0.8.64',
  codefresh:http      'Codefresh-Agent': 'cli' },
  codefresh:http   json: true,
  codefresh:http   timeout: 30000 } +0ms
```