### PR TITLE
Updating README for new API token link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In case you have node.js installed you can easily install with NPM.
 For other installation possibilities check out the <a href="http://cli.codefresh.io/installation" target="_blank">installation documentation</a>.
 
 ## Authenticate
-Generate a new api key from the <a href="https://g.codefresh.io/account/tokens" target="_blank">account settings</a> page.
+Generate a new api key from the <a href="https://g.codefresh.io/account-conf/tokens" target="_blank">account settings</a> page.
 
 `codefresh auth create-context --api-key {{API_KEY}}`
 


### PR DESCRIPTION
## Description
The API token link was old, and redirected instead to the "Repositories" page. Updating the README so that it goes to the proper API token page.

## Motivation and Context
Was trying to get the CodeFresh CLI set up, but ran into the issue where the token page URL wasn't correct.

## How Has This Been Tested?
Visiting the new URL will direct you to the proper page now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
