### PR TITLE
add cluster --name-overwrite and --behind-firewall flags

### DIFF
--- a/lib/interface/cli/commands/cluster/create.cmd.js
+++ b/lib/interface/cli/commands/cluster/create.cmd.js
@@ -33,16 +33,32 @@ const command = new Command({
                 default: 'default',
                 required: true,
             })
+            .option('name-overwrite', {
+                describe: 'spesify under which name the cluster should be saved in Codefresh, default is the context name',
+            })
+            .option('behind-firewall', {
+                describe: 'Spesify whenever the cluster is behined firewall',
+                default: false,
+                type: 'boolean',
+            })
             .example('codefresh create cluster --kube-context production', 'Creating a cluster in codefresh');
     },
     handler: async (argv) => {
         const context = authManager.getCurrentContext();
-        const { namespace, serviceaccount, 'kube-context': name } = argv;
+        const {
+            namespace,
+            serviceaccount,
+            'kube-context': contextName,
+            'behind-firewall': behindFirewall,
+            'name-overwrite': name,
+        } = argv;
         await cluster.createCluster({
-            name,
+            contextName,
             context,
             namespace,
             serviceaccount,
+            behindFirewall,
+            name,
         });
     },
 });

--- a/lib/logic/api/cluster.js
+++ b/lib/logic/api/cluster.js
@@ -14,13 +14,36 @@ const { CODEFRESH_PATH } = require('../../interface/cli/defaults');
 
 const _createClusterScript = (info, filePath) => {
     const {
+        contextName,
         name,
+        behindFirewall,
         context,
         namespace,
         serviceaccount,
     } = info;
     fs.chmodSync(filePath, '755');
-    const clusterScript = spawn(filePath, ['create', '--c', name, '--token', context.token, '--api-host', `${context.url}/`, '--namespace', namespace, '--serviceaccount', serviceaccount]);
+    const commands = [
+        'create',
+        '--c',
+        contextName,
+        '--token',
+        context.token,
+        '--api-host',
+        `${context.url}/`,
+        '--namespace',
+        namespace,
+        '--serviceaccount',
+        serviceaccount,
+    ];
+    if (name) {
+        commands.push('--name-overwrite');
+        commands.push(name);
+    }
+
+    if (behindFirewall) {
+        commands.push('--behind-firewall');
+    }
+    const clusterScript = spawn(filePath, commands);
     clusterScript.stdout.pipe(process.stdout);
     clusterScript.stderr.pipe(process.stderr);
     process.stdin.pipe(clusterScript.stdin);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
add flags to allow overwrite the name of the cluster and to specify if the cluster is behind firewall