### PR TITLE
Updated yq binary building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,22 @@
+# go hub binary
 FROM golang:alpine as go
-
 RUN apk --update add ca-certificates git
-
 RUN go get github.com/github/hub
 
-FROM python:3.7 as yq
-
+# python yq binary
+FROM six8/pyinstaller-alpine as yq
 ARG YQ_VERSION=2.10.0
+ENV PATH="/pyinstaller:$PATH"
+RUN pip install yq==${YQ_VERSION}
+RUN pyinstaller --noconfirm --onefile --log-level DEBUG --clean --distpath /tmp/ $(which yq)
 
-RUN pip install yq==${YQ_VERSION} && \
-    pip install pyinstaller==3.6 && \
-    pyinstaller --onefile /usr/local/bin/yq --dist /tmp/
-
+# Main
 FROM codefresh/node:10.15.3-alpine3.11
 
 RUN apk --update add --no-cache ca-certificates git curl bash yarn
 
 COPY --from=go /go/bin/hub /usr/local/bin/hub
 COPY --from=yq /tmp/yq /usr/local/bin/yq
-
-# add glibc compatibility layer for the compiled yq
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-2.30-r0.apk && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-bin-2.30-r0.apk && \
-    apk add glibc-2.30-r0.apk glibc-bin-2.30-r0.apk && \
-    rm /etc/apk/keys/sgerrand.rsa.pub 
 
 ARG JQ_VERSION=1.6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.41.11",
+  "version": "0.41.12",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
## Overview
Build the `yq` binary with the native Alpine **musl** library instead of **glibc**.

## Testing
```
docker build -t test/cli .

docker run \
  --rm \
  -ti \
  --entrypoint bash \
  -v /<path to any>/step.yaml:/tmp/step.yaml \
  test/cli -c "cat /tmp/step.yaml | yq -r .metadata.version"
```