### PR TITLE
Remove devDependencies from yarn.lock file in the prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN yarn install --prod --frozen-lockfile && \
 
 COPY . /cf-cli
 
+RUN for p in $(cat package.json | jq -r '.devDependencies | keys[] '); \
+    do yarn remove $p; done
+    
 RUN yarn generate-completion
 RUN apk del yarn
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.41.13",
+  "version": "0.41.14",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
There are security scanning tools, which look into the yarn.lock file and have _no option to ignore devDependencies_, even _despite the fact they are actually not installed_ (because of the --production flag)

So to shut off the security alerts from those tools, it is needed to remove the records for these deps from the yarn.lock in the production image