### PR TITLE
Add error handling when unable to get config from cluster

### DIFF
--- a/lib/interface/cli/helpers/kubernetes.js
+++ b/lib/interface/cli/helpers/kubernetes.js
@@ -11,7 +11,12 @@ const _getKubeConfig = (kubeconfigPath) => {
     if (fs.existsSync(kubePath)) {
         kc.loadFromFile(kubePath);
     } else {
-        kc.loadFromCluster();
+        try {
+            kc.loadFromCluster();
+        } catch (err) {
+            console.error(`Unable to load kubeconfig: ${err}`);
+            console.error(`Have you installed and configured kubectl?`)
+        }
     }
 
     return kc;


### PR DESCRIPTION
Hello! I ran into an error while trying to install the runner, so I figured I'd make a quick PR. What happened was this:

I tried to init a new runner per the instructions in the UI, and was met with this:

```
phil@pzona:~# codefresh runner init --token xxx.yyy
This installer will guide you through the Codefresh Runner installation process
Error: ENOENT: no such file or directory, open '/var/run/secrets/kubernetes.io/serviceaccount/token'
```

Not the most useful message, so I found that the CLI tries to load the kubeconfig from its path, then directly from the cluster, and doesn't fall back to anything else. I added an extra step to make this failure a bit more intuitive.

A side note - I didn't realize at first that the runner host would need to be configured for the cluster before initializing. After a second thinking about it, of course it would, but I didn't see this mentioned in the docs at all so you might consider adding a note about that in a "prerequisites" section or something. That would have been helpful in this situation as well.

Anyway, I hope this is helpful. I'm not deeply invested in the actual error text here, so feel free to make changes if you are interested in merging this :)