### PR TITLE
Fix typo in web doc category

### DIFF
--- a/lib/interface/cli/commands/components/update.cmd.js
+++ b/lib/interface/cli/commands/components/update.cmd.js
@@ -7,7 +7,7 @@ const command = new Command({
     parent: componentsRoot,
     description: 'Update Codefresh CLI components',
     webDocs: {
-        category: 'Componenets',
+        category: 'Components',
         title: 'Update',
     },
     builder: yargs => yargs


### PR DESCRIPTION
Just an extra letter in the category "Components" (was "Componenets"). I don't believe this has any effect on the code - it seems to only be used to generate the sidebar categories for the CLI docs.