### PR TITLE
Remove old disclaimer from CLI doc

### DIFF
--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -14,7 +14,6 @@ Updating the authentication configuration is done via an API-KEY you generate fr
 
 If you already have an API-KEY you can just use it.<br />
 You can generate a new one from the <a href="https://g.codefresh.io/user/settings" target="_blank">user settings</a> page. <br />
-{{% alert theme="warning" %}}You must be an account admin to generate api keys{{% /alert %}}
  
 Once you have an API key, create a new authentication context:<br> `codefresh auth create-context --api-key {API_KEY}`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.75.9",
+  "version": "0.75.10",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
Removed old disclaimer "You must be an account admin to generate api keys". A customer noticed you don't need to be an admin to create an API key. I verified that this to be the case in a demo account.