### PR TITLE
Update helm repo url

### DIFF
--- a/lib/interface/cli/commands/hybrid/init.cmd.js
+++ b/lib/interface/cli/commands/hybrid/init.cmd.js
@@ -943,7 +943,7 @@ const initCmd = new Command({
 
         if (shouldUseHelm) {
             console.log(colors.blue('\nTo complete helm installation run: '));
-            console.log('    helm repo add cf-runtime https://h.cfcr.io/codefresh-inc/runtime');
+            console.log('    helm repo add cf-runtime https://chartmuseum.codefresh.io/cf-runtime');
             console.log(`    helm install cf-runtime cf-runtime/cf-runtime -f ${helmValuesFile} --create-namespace --namespace ${kubeNamespace}`);
             console.log(colors.blue('\nIn order to test your runner helm based installation please execute:\n'));
             console.log(`    codefresh runner execute-test-pipeline --runtime-name ${installationPlan.getContext('runtimeName')}\n`);


### PR DESCRIPTION
In the Helm installation section of the [Runner Docs](https://codefresh.io/docs/docs/administration/codefresh-runner/#installing-codefresh-runner-with-helm) the helm repo url is now https://chartmuseum.codefresh.io/cf-runtime

 