### PR TITLE
fix(downloader): replace `zip` with `adm-zip`

### DIFF
--- a/lib/binary/downloader.js
+++ b/lib/binary/downloader.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const rp = require('request-promise');
 const request = require('request');
 const compareVersions = require('compare-versions');
-const zip = require('zip');
+const AdmZip = require('adm-zip');
 const tarStream = require('tar-stream');
 const {
     resolve, join,
@@ -12,7 +12,7 @@ const {
     homedir, arch,
 } = require('os');
 const {
-    existsSync, mkdirSync, readFileSync, createWriteStream, writeFile, readFile,
+    existsSync, mkdirSync, readFileSync, createWriteStream, writeFile,
     createReadStream,
 } = require('fs');
 const { createGunzip } = require('zlib');
@@ -25,20 +25,9 @@ pipeline = promisify(pipeline);
 const CODEFRESH_PATH = resolve(homedir(), '.Codefresh');
 
 async function unzipFile(zipPath, outputPath) {
-    const zipBuffer = await Promise.fromCallback((cb) => readFile(zipPath, cb));
-    const zr = zip.Reader(zipBuffer);
-
-    const fileWrites = [];
-    zr.forEach((entry) => {
-        if (!entry.isFile()) {
-            return;
-        }
-
-        const outputFilePath = join(outputPath, entry.getName());
-        fileWrites.push(Promise.fromCallback((cb) => writeFile(outputFilePath, entry.getData(), { mode: entry.getMode() }, cb)));
-    });
-
-    return Promise.all(fileWrites);
+    const zip = new AdmZip(zipPath);
+    const extractAll = promisify(zip.extractAllToAsync.bind(zip));
+    return extractAll(outputPath, true, true);
 }
 
 async function untarFile(tarPath, outputPath) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@codefresh-io/docker-reference": "^0.0.5",
-    "adm-zip": "^0.5.5",
+    "adm-zip": "^0.5.10",
     "ajv": "^6.12.6",
     "bluebird": "^3.5.1",
     "cf-errors": "^0.1.16",
@@ -87,8 +87,7 @@
     "uuid": "^3.1.0",
     "yaml": "^1.10.0",
     "yargs": "^15.4.1",
-    "yargs-parser": "^13.0.0",
-    "zip": "^1.2.0"
+    "yargs-parser": "^13.0.0"
   },
   "devDependencies": {
     "@types/node-forge": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,10 +335,10 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-adm-zip@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.5.tgz#b6549dbea741e4050309f1bb4d47c47397ce2c4f"
-  integrity sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==
+adm-zip@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.10.tgz#4a51d5ab544b1f5ce51e1b9043139b639afff45b"
+  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
 
 agent-base@6:
   version "6.0.2"


### PR DESCRIPTION
`zip` library returns `false` for file permissions on Windows ([library source](https://github.com/kriskowal/zip/blob/master/zip.js#L227)), which is incompatible with file mode expected by Node.js File System API ([File system API: chmod](https://nodejs.org/docs/latest-v18.x/api/fs.html#file-modes)). This leads to TypeError in runtime.

`adm-zip`, instead, handles such cases correctly.

Fixes [#CR-18233](https://codefresh-io.atlassian.net/browse/CR-18233)