### PR TITLE
build: exlude redundant files from package, downgrade node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "0.88.3",
+  "version": "0.88.4",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,
@@ -19,6 +19,13 @@
   "bin": {
     "codefresh": "lib/interface/cli/codefresh"
   },
+  "files": [
+    "brew",
+    "lib",
+    "check-version.js",
+    "openapi.json",
+    "run-check-version.js"
+  ],
   "repository": "git+https://github.com/codefresh-io/cli.git",
   "keywords": [
     "command line"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "jest .spec.js --coverage",
     "e2e": "bash e2e/e2e.spec.sh",
     "eslint": "eslint --fix lib/logic/**",
-    "pkg": "npx pkg . -t node22-alpine-x64,node22-alpine-arm64,node22-macos-x64,node22-linux-x64,node22-win-x64,node22-linux-arm64 --out-path ./dist",
+    "pkg": "npx pkg . -t node20-alpine-x64,node20-alpine-arm64,node20-macos-x64,node20-linux-x64,node20-win-x64,node20-linux-arm64 --out-path ./dist",
     "serve-docs": "yarn build-local-docs && cd temp && hugo server -D",
     "serve-docs-beta": "ALLOW_BETA_COMMANDS=true yarn build-local-docs && cd temp && hugo server -D",
     "build-local-docs": "node ./docs/index.js",


### PR DESCRIPTION
## What

This excludes redundant files from published package.

