### PR TITLE
chore: update images and nodejs dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:24.18.0-alpine3.24
 ARG TARGETPLATFORM
-RUN apk --update add --no-cache \
+RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
+  && apk --update add --no-cache \
     bash \
     ca-certificates \
     curl \
     git \
-    jq
+    jq@edge
 RUN npm upgrade -g npm
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -8,8 +8,9 @@ RUN apt update \
     ca-certificates \
     curl \
     git \
-    jq \
-    && ln -s /bin/busybox /usr/bin/[[
+    && ln -s /bin/busybox /usr/bin/[[ \
+    && curl -L "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-$(dpkg --print-architecture)" -o /usr/local/bin/jq \
+    && chmod +x /usr/local/bin/jq
 RUN npm upgrade -g npm
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl

--- a/Dockerfile-debian-rootless
+++ b/Dockerfile-debian-rootless
@@ -7,8 +7,9 @@ RUN apt update \
     ca-certificates \
     curl \
     git \
-    jq \
-    && ln -s /bin/busybox /usr/bin/[[
+    && ln -s /bin/busybox /usr/bin/[[ \
+    && curl -L "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-$(dpkg --print-architecture)" -o /usr/local/bin/jq \
+    && chmod +x /usr/local/bin/jq
 RUN npm upgrade -g npm
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl

--- a/Dockerfile-rootless
+++ b/Dockerfile-rootless
@@ -1,11 +1,12 @@
 FROM node:24.18.0-alpine3.24
 ARG TARGETPLATFORM
-RUN apk --update add --no-cache \
+RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
+  && apk --update add --no-cache \
     bash \
     ca-certificates \
     curl \
     git \
-    jq
+    jq@edge
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 WORKDIR /cf-cli

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4415,9 +4415,9 @@ into-stream@^9.1.0:
   integrity sha512-DRsRnQrbzdFjaQ1oe4C6/EIUymIOEix1qROEJTF9dbMq+M4Zrm6VaLp6SD/B9IsiEjPZuBSnWWFN+udajugdWA==
 
 ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+  version "10.3.1"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz#929f9629d1724f7e1b7485ce89752f3675336a10"
+  integrity sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,9 +2491,9 @@ bowser@^2.11.0:
   integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.17"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz#a375e14e41d672617de69526be02d0d7751a6909"
+  integrity sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,9 +2491,9 @@ bowser@^2.11.0:
   integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -3796,9 +3796,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-xml-builder@^1.1.5:
   version "1.1.8"
@@ -4415,9 +4415,9 @@ into-stream@^9.1.0:
   integrity sha512-DRsRnQrbzdFjaQ1oe4C6/EIUymIOEix1qROEJTF9dbMq+M4Zrm6VaLp6SD/B9IsiEjPZuBSnWWFN+udajugdWA==
 
 ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
+  integrity sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"


### PR DESCRIPTION
## What

## Why

## Notes

<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/cli~ ↓↓↓ ⚠️ -->

## Security Report — codefresh/cli

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/cli:cfs-7190-security@sha256:340ebfb7301e12ada01faf2d23b06186a3c5b58eb68b4969e9c34709cb31bf2d](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A340ebfb7301e12ada01faf2d23b06186a3c5b58eb68b4969e9c34709cb31bf2d)
>
> **Baseline**:
[quay.io/codefresh/cli:master@sha256:d2fa279c508fcbd38c265c49b9511d42c5b4c74091a0c51f7e13208e65a50000](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253Ad2fa279c508fcbd38c265c49b9511d42c5b4c74091a0c51f7e13208e65a50000)

### Fixed CVEs: 13
#### 🔴 High: 3
- CVE-2026-69192 in `ip-address@10.2.0` at `/cf-cli/node_modules/ip-address`
- CVE-2026-32316 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-14257 in `brace-expansion@1.1.16` at `/cf-cli/node_modules/brace-expansion`
#### 🟠 Medium: 7
- CVE-2026-69198 in `ip-address@10.2.0` at `/cf-cli/node_modules/ip-address`
- CVE-2026-54272 in `ip-address@10.2.0` at `/cf-cli/node_modules/ip-address`
- CVE-2026-43896 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-43894 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-41257 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-40612 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-33947 in `jq@1.8.1-r0` at `unknown path`
#### 🟡 Low: 3
- CVE-2026-69152 in `brace-expansion@1.1.16` at `/cf-cli/node_modules/brace-expansion`
- CVE-2026-43895 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-41256 in `jq@1.8.1-r0` at `unknown path`

### Fixed issues: 10
<!-- Fixed issues: ~[{"identifier":"CFS-15554","dueDate":"2026-09-04"},{"identifier":"CFS-15543","dueDate":"2026-10-04"},{"identifier":"CFS-15539","dueDate":"2026-10-04"},{"identifier":"CFS-15520","dueDate":"2026-10-04"},{"identifier":"CFS-15506","dueDate":"2026-10-04"},{"identifier":"CFS-15491","dueDate":"2026-09-04"},{"identifier":"CFS-15362","dueDate":"2026-09-03"},{"identifier":"CFS-15186","dueDate":"2026-08-25"},{"identifier":"CFS-7196","dueDate":"2026-08-12"},{"identifier":"CFS-7190","dueDate":"2026-08-12"}]~ -->
- Fixes [CFS-15554](https://linear.app/octopus/issue/CFS-15554/security-codefreshcli-cve-2026-69192)
- Fixes [CFS-15543](https://linear.app/octopus/issue/CFS-15543/security-codefreshcli-cve-2026-69198)
- Fixes [CFS-15539](https://linear.app/octopus/issue/CFS-15539/security-codefreshcli-cve-2026-54272)
- Fixes [CFS-15520](https://linear.app/octopus/issue/CFS-15520/security-codefreshcli-cve-2026-69198)
- Fixes [CFS-15506](https://linear.app/octopus/issue/CFS-15506/security-codefreshcli-cve-2026-54272)
- Fixes [CFS-15491](https://linear.app/octopus/issue/CFS-15491/security-codefreshcli-cve-2026-69192)
- Fixes [CFS-15362](https://linear.app/octopus/issue/CFS-15362/security-codefreshcli-cve-2026-69152)
- Fixes [CFS-15186](https://linear.app/octopus/issue/CFS-15186/security-codefreshcli-cve-2026-14257)
- Fixes [CFS-7196](https://linear.app/octopus/issue/CFS-7196/security-codefreshcli-cve-2026-43895-low)
- Fixes [CFS-7190](https://linear.app/octopus/issue/CFS-7190/security-codefreshcli-cve-2026-41256-low)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/cli~ ↑↑↑ ⚠️ -->


