### PR TITLE
build: migrate image to DHI

### DIFF
--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -15,6 +15,7 @@ ARG TARGETPLATFORM
 #COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 #ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 WORKDIR /cf-cli
+ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 COPY package.json yarn.lock check-version.js run-check-version.js /cf-cli/
 RUN yarn install --prod --frozen-lockfile && \
     yarn cache clean
@@ -28,7 +29,7 @@ FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:91f550e9c6
 WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
-ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
+COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -25,12 +25,11 @@ RUN yarn generate-completion
 #purpose of security
 #RUN npm -g uninstall npm
 
-FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:800314b290fd15c92fea62ec0b3374c84f0edb222a80e37a53ebbd449572ef62 as base
+FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:92241510202a764f988381982b5d953cac7764e06fd94c30813e01a4a782a80a as base
 RUN busybox --install
 COPY --chmod=755 --from=build  /cf-cli /cf-cli
 WORKDIR /cf-cli
 USER root
-COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 COPY --chmod=775 --from=octopusdeploy/dhi-kubectl:1.36-debian13 /usr/local/bin/kubectl /usr/local/bin/kubectl
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN codefresh components update --location components

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -30,7 +30,7 @@ WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --chown=node:node --chmod=755 . .
+COPY --chown=node:node --chmod=755 /cf-cli /cf-cli
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,4 +1,4 @@
-FROM octopusdeploy/dhi-node:24-debian13-dev@sha256:1684b453b97f985c384af99f71507adf5727e24e76c6cd8c1a2da949ad8588e0 as build
+FROM octopusdeploy/dhi-node:24-debian13-dev@sha256:fe091924af637178000e4eb34caec858c935c5264a55ada03088890c7b6a8de2 as build
 ARG TARGETPLATFORM
 #RUN apt update \
 #    && apt -y install \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,19 +1,19 @@
-FROM node:24.18.0-trixie-slim
+FROM octopusdeploy/dhi-node:24-debian13-dev@sha256:1684b453b97f985c384af99f71507adf5727e24e76c6cd8c1a2da949ad8588e0 as build
 ARG TARGETPLATFORM
-RUN apt update \
-    && apt -y install \
-    apt-transport-https \
-    bash \
-    busybox \
-    ca-certificates \
-    curl \
-    git \
-    && ln -s /bin/busybox /usr/bin/[[ \
-    && curl -L "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-$(dpkg --print-architecture)" -o /usr/local/bin/jq \
-    && chmod +x /usr/local/bin/jq
-RUN npm upgrade -g npm
-COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
-ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
+#RUN apt update \
+#    && apt -y install \
+#    apt-transport-https \
+#    bash \
+#    busybox \
+#    ca-certificates \
+#    curl \
+#    git \
+#    && ln -s /bin/busybox /usr/bin/[[ \
+#    && curl -L "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-$(dpkg --print-architecture)" -o /usr/local/bin/jq \
+#    && chmod +x /usr/local/bin/jq
+#RUN npm upgrade -g npm
+#COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
+#ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 WORKDIR /cf-cli
 COPY package.json yarn.lock check-version.js run-check-version.js /cf-cli/
 RUN yarn install --prod --frozen-lockfile && \
@@ -22,9 +22,15 @@ COPY . /cf-cli
 RUN yarn generate-completion
 
 #purpose of security
-RUN npm -g uninstall npm
+#RUN npm -g uninstall npm
 
+FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:91f550e9c617363429620203161cb44e7270efe125beb7b8b0dbb8b4f448a745 as base
+WORKDIR /cf-cli
+USER root
+COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
+ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
+RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components
 
 # Node.js warnings must be suppressed to ensure that automations relying on exact output are not disrupted

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -30,6 +30,7 @@ WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --chown=node:node --chmod=755 . .
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -24,7 +24,7 @@ RUN yarn generate-completion
 #purpose of security
 #RUN npm -g uninstall npm
 
-FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:92241510202a764f988381982b5d953cac7764e06fd94c30813e01a4a782a80a as base
+FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:ba88e3250a5efc62df36d95e2305a5811a1b1671f9aa65fcbaeb664bb8c371cd as base
 RUN busybox --install
 COPY --chmod=755 --from=build  /cf-cli /cf-cli
 WORKDIR /cf-cli

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -30,7 +30,7 @@ WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --chown=node:node --chmod=755 /cf-cli /cf-cli
+COPY --chown=node:node --chmod=755 --from=build  . .
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -15,7 +15,6 @@ ARG TARGETPLATFORM
 #COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 #ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 WORKDIR /cf-cli
-ADD --chmod=775 https://dl.k8s.io/release/v1.36.1/bin/${TARGETPLATFORM}/kubectl /usr/local/bin/kubectl
 COPY package.json yarn.lock check-version.js run-check-version.js /cf-cli/
 RUN yarn install --prod --frozen-lockfile && \
     yarn cache clean
@@ -27,7 +26,7 @@ RUN yarn generate-completion
 
 FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:92241510202a764f988381982b5d953cac7764e06fd94c30813e01a4a782a80a as base
 RUN busybox --install
-COPY --chmod=755 --from=build  /cf-cli /cf-cli
+#COPY --chmod=755 --from=build  /cf-cli /cf-cli
 WORKDIR /cf-cli
 USER root
 COPY --chmod=775 --from=octopusdeploy/dhi-kubectl:1.36-debian13 /usr/local/bin/kubectl /usr/local/bin/kubectl

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -26,11 +26,11 @@ RUN yarn generate-completion
 #RUN npm -g uninstall npm
 
 FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:91f550e9c617363429620203161cb44e7270efe125beb7b8b0dbb8b4f448a745 as base
+COPY --chmod=755 --from=build  /cf-cli /cf-cli
 WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --chown=node:node --chmod=755 --from=build  . .
 RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -26,7 +26,8 @@ RUN yarn generate-completion
 #RUN npm -g uninstall npm
 
 FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:91f550e9c617363429620203161cb44e7270efe125beb7b8b0dbb8b4f448a745 as base
-COPY --chmod=755 --from=build  /cf-cli /cf-cli
+#COPY --chmod=755 --from=build  /cf-cli /cf-cli
+COPY --chmod=755 --from=build . /cf-cli
 WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -21,18 +21,19 @@ RUN yarn install --prod --frozen-lockfile && \
     yarn cache clean
 COPY . /cf-cli
 RUN yarn generate-completion
+RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 
 #purpose of security
 #RUN npm -g uninstall npm
 
 FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:91f550e9c617363429620203161cb44e7270efe125beb7b8b0dbb8b4f448a745 as base
-#COPY --chmod=755 --from=build  /cf-cli /cf-cli
-COPY --chmod=755 --from=build . /cf-cli
+COPY --chmod=755 --from=build  /cf-cli /cf-cli
+#COPY --chmod=755 --from=build . /cf-cli
 WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
 COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
-RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
+COPY --chmod=755 --from=build /usr/local/bin/codefresh /usr/local/bin/codefresh
 RUN ln -s /bin/busybox /usr/bin/[[
 RUN codefresh components update --location components
 

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -26,7 +26,7 @@ RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 #purpose of security
 #RUN npm -g uninstall npm
 
-FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:91f550e9c617363429620203161cb44e7270efe125beb7b8b0dbb8b4f448a745 as base
+FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:b7b0cfb1aa32c94819c267a41aedec1042d76f9d1a3067989d91dd9efba93139 as base
 COPY --chmod=755 --from=build  /cf-cli /cf-cli
 #COPY --chmod=755 --from=build . /cf-cli
 WORKDIR /cf-cli

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -26,7 +26,7 @@ RUN yarn generate-completion
 
 FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:92241510202a764f988381982b5d953cac7764e06fd94c30813e01a4a782a80a as base
 RUN busybox --install
-#COPY --chmod=755 --from=build  /cf-cli /cf-cli
+COPY --chmod=755 --from=build  /cf-cli /cf-cli
 WORKDIR /cf-cli
 USER root
 COPY --chmod=775 --from=octopusdeploy/dhi-kubectl:1.36-debian13 /usr/local/bin/kubectl /usr/local/bin/kubectl

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -21,20 +21,18 @@ RUN yarn install --prod --frozen-lockfile && \
     yarn cache clean
 COPY . /cf-cli
 RUN yarn generate-completion
-RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 
 #purpose of security
 #RUN npm -g uninstall npm
 
-FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:b7b0cfb1aa32c94819c267a41aedec1042d76f9d1a3067989d91dd9efba93139 as base
+FROM octopusdeploy/dhi-node:24-debian_cf-cli-node-24-debian-13@sha256:800314b290fd15c92fea62ec0b3374c84f0edb222a80e37a53ebbd449572ef62 as base
+RUN busybox --install
 COPY --chmod=755 --from=build  /cf-cli /cf-cli
-#COPY --chmod=755 --from=build . /cf-cli
 WORKDIR /cf-cli
 USER root
 COPY --from=mikefarah/yq:4.53.3 /usr/bin/yq /usr/local/bin/yq
-COPY --chmod=755 --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --chmod=755 --from=build /usr/local/bin/codefresh /usr/local/bin/codefresh
-RUN ln -s /bin/busybox /usr/bin/[[
+COPY --chmod=775 --from=octopusdeploy/dhi-kubectl:1.36-debian13 /usr/local/bin/kubectl /usr/local/bin/kubectl
+RUN ln -s $(pwd)/lib/interface/cli/codefresh /usr/local/bin/codefresh
 RUN codefresh components update --location components
 
 # Node.js warnings must be suppressed to ensure that automations relying on exact output are not disrupted

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codefresh",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Codefresh command line utility",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
## What

## Why

## Notes

<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/cli~ ↓↓↓ ⚠️ -->

## Security Report — codefresh/cli

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/cli:cf-2192@sha256:f7348b90e83e3f0a76e49cbc18d35df3cc514b690fac70914c37961108451e1b](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253Af7348b90e83e3f0a76e49cbc18d35df3cc514b690fac70914c37961108451e1b)
>
> **Baseline**:
[quay.io/codefresh/cli:master@sha256:340ebfb7301e12ada01faf2d23b06186a3c5b58eb68b4969e9c34709cb31bf2d](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A340ebfb7301e12ada01faf2d23b06186a3c5b58eb68b4969e9c34709cb31bf2d)

### Fixed CVEs: 0

### Fixed issues: 0


<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/cli~ ↑↑↑ ⚠️ -->


