### PR TITLE
chore: update node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18.0-alpine3.24
+FROM node:24.20-alpine3.24
 ARG TARGETPLATFORM
 RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
   && apk --update add --no-cache \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,4 +1,4 @@
-FROM node:24.18.0-trixie-slim
+FROM node:24.20-trixie-slim
 ARG TARGETPLATFORM
 RUN apt update \
     && apt -y install \

--- a/Dockerfile-debian-rootless
+++ b/Dockerfile-debian-rootless
@@ -1,4 +1,4 @@
-FROM node:24.18.0-trixie-slim
+FROM node:24.20-trixie-slim
 ARG TARGETPLATFORM
 RUN apt update \
     && apt -y install \

--- a/Dockerfile-rootless
+++ b/Dockerfile-rootless
@@ -1,4 +1,4 @@
-FROM node:24.18.0-alpine3.24
+FROM node:24.20-alpine3.24
 ARG TARGETPLATFORM
 RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
   && apk --update add --no-cache \


### PR DESCRIPTION
## What
Closes https://linear.app/octopus/issue/CFS-16391/security-codefreshcli-cve-2026-58043

<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/cli~ ↓↓↓ ⚠️ -->

## Security Report — codefresh/cli

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/cli:cfs-16391-security-fixes@sha256:862baf1616a7a1f099ce5b22cf8fe007ee70d99d34263aeb9c8e85a991fc6f7c](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A862baf1616a7a1f099ce5b22cf8fe007ee70d99d34263aeb9c8e85a991fc6f7c)
>
> **Baseline**:
[quay.io/codefresh/cli:master@sha256:ff199f10cafabb5ea3289ba56337e552e39bfd59764c55820e61819c564e24cb](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253Aff199f10cafabb5ea3289ba56337e552e39bfd59764c55820e61819c564e24cb)

### Fixed CVEs: 3
#### 🔴 High: 1
- CVE-2026-58043 in `node@24.18.0` at `/usr/local/bin/node`
#### 🟠 Medium: 2
- CVE-2026-56847 in `node@24.18.0` at `/usr/local/bin/node`
- CVE-2026-56850 in `node@24.18.0` at `/usr/local/bin/node`

### Fixed issues: 5
<!-- Fixed issues: ~[{"identifier":"CFS-17021","dueDate":"2026-10-26"},{"identifier":"CFS-16935","dueDate":"2026-10-26"},{"identifier":"CFS-16777","dueDate":"2026-10-26"},{"identifier":"CFS-16492","dueDate":"2026-10-26"},{"identifier":"CFS-16391","dueDate":"2026-09-26"}]~ -->
- Fixes [CFS-17021](https://linear.app/octopus/issue/CFS-17021/security-codefreshcli-cve-2026-56847)
- Fixes [CFS-16935](https://linear.app/octopus/issue/CFS-16935/security-codefreshcli-cve-2026-56847)
- Fixes [CFS-16777](https://linear.app/octopus/issue/CFS-16777/security-codefreshcli-cve-2026-56850)
- Fixes [CFS-16492](https://linear.app/octopus/issue/CFS-16492/security-codefreshcli-cve-2026-56847)
- Fixes [CFS-16391](https://linear.app/octopus/issue/CFS-16391/security-codefreshcli-cve-2026-58043)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/cli~ ↑↑↑ ⚠️ -->

